### PR TITLE
Reverted the t64 change for openssl package.

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,5 @@
 # Getting latest version of openssl in debian 3.1 branch.
-git_src --branch debian/openssl-3.1.5-1.1 https://salsa.debian.org/debian/openssl.git
+git_src --branch debian/openssl-3.1.5-1 https://salsa.debian.org/debian/openssl.git
 
 # Apply upstream patches
 cp patches/*.patch $dir/src/debian/patches/
@@ -12,4 +12,4 @@ sed -i 's/dpkg-dev (>= 1.22.5)/dpkg-dev (>= 1.22.4)/' $dir/src/debian/control
 
 # set the corresponding version of the package.
 version_orig=3.1.7
-version="$version_orig-0"
+version="$version_orig-1"


### PR DESCRIPTION
In this PR, we downgrade the OpenSSL package to not include t64 changes. 

With the latest package build for 1443, we run in a problem with installing `libssl3`. The problem is as [follows](https://github.com/gardenlinux/gardenlinux/actions/runs/11269028441/job/31336856041):

```
...
 [.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21]  installing libssl3t64:amd64 would break libssl3:amd64, and
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21]  deconfiguration is not permitted (--auto-deconfigure might help)
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21] dpkg: version 3.1.7-0gardenlinux0+bp1443 of openssl already installed, skipping
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21] Errors were encountered while processing:
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21]  /var/cache/apt/archives/libssl3t64_3.1.7-0gardenlinux0+bp1443_amd64.deb
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21] dpkg: version 20240203 of ca-certificates already installed, skipping
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21] dpkg: regarding .../libssl3t64_3.1.7-0gardenlinux0+bp1443_amd64.deb containing libssl3t64:amd64:
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21]  libssl3t64 breaks libssl3 (<< 3.1.7-0gardenlinux0+bp1443)
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21]   libssl3:amd64 (version 3.1.5-1) is present and installed.
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21] 
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21] dpkg: error processing archive /var/cache/apt/archives/libssl3t64_3.1.7-0gardenlinux0+bp1443_amd64.deb (--unpack):
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21]  installing libssl3t64:amd64 would break libssl3:amd64, and
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21]  deconfiguration is not permitted (--auto-deconfigure might help)
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21] dpkg: version 3.1.7-0gardenlinux0+bp1443 of openssl already installed, skipping
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21] Errors were encountered while processing:
[.build/bootstrap-amd64-1443.14-4212afb5.tar 2024-10-10 07:02:21]  /var/cache/apt/archives/libssl3t64_3.1.7-0gardenlinux0+bp1443_amd64.deb
completed in 56 seconds
make: *** [Makefile:43: .build/bootstrap-amd64-1443.14-4212afb5.tar] Error 1
```
The repository was updated to contain the updated version of openssl-3.1.7, this also includes a newer version of the `libssl3` package. However, this package has been changed to have a [t64 suffix](https://salsa.debian.org/debian/openssl/-/commit/cd4af2a4fab1ab3504d7c5c100df44733ecbc088#58ef006ab62b83b4bec5d81fe5b32c3b4c2d1cc2_32_32). This creates two separated versions of `libssl3`: 

- `libssl3-3.1.5`
- `libssl3t64-3.1.7`
 
`debootstrap` cannot handle this problem in the 1443 build environment. This was fixed by switching into the [mmdebstrap](https://github.com/gardenlinux/builder/blob/357fbe01a5a95854ccb5065c28fc6eca13466a46/builder/bootstrap#L14). 

The fix is to build OpenSSL without the t64 suffix and make the repo overwrite the original `libssl3` package
