### PR TITLE
various fips patches

### DIFF
--- a/upstream_patches/0037-FIPS-ECDSA-allow-truncated-SHA512.patch
+++ b/upstream_patches/0037-FIPS-ECDSA-allow-truncated-SHA512.patch
@@ -1,0 +1,30 @@
+From 06de4513841d9c942591ddeb4eb961d8378a6f8e Mon Sep 17 00:00:00 2001
+From: nkraetzschmar <9020053+nkraetzschmar@users.noreply.github.com>
+Date: Fri, 12 Jun 2026 12:35:07 +0000
+Subject: [PATCH] providers: allow truncated SHA-512 digests for ECDSA in FIPS
+
+FIPS 186-5 lists SHA2-512/224 and SHA2-512/256 as approved digests for
+ECDSA signature generation and verification. The truncated-SHA-512 gate
+in ossl_fips_ind_digest_sign_check is currently passed sha512_trunc_allowed=0
+on the ECDSA call site, while RSA already passes 1. Flip the ECDSA flag
+so SHA2-512/224 and SHA2-512/256 stop showing as unapproved.
+---
+ providers/implementations/signature/ecdsa_sig.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/providers/implementations/signature/ecdsa_sig.c b/providers/implementations/signature/ecdsa_sig.c
+index d57c2d745a..253c711ce5 100644
+--- a/providers/implementations/signature/ecdsa_sig.c
++++ b/providers/implementations/signature/ecdsa_sig.c
+@@ -219,7 +219,7 @@ static int ecdsa_setup_md(PROV_ECDSA_CTX *ctx,
+         if (!ossl_fips_ind_digest_sign_check(OSSL_FIPS_IND_GET(ctx),
+                 OSSL_FIPS_IND_SETTABLE1,
+                 ctx->libctx,
+-                md_nid, sha1_allowed, 0, desc,
++                md_nid, sha1_allowed, 1, desc,
+                 ossl_fips_config_signature_digest_check))
+             goto err;
+     }
+-- 
+2.47.3
+

--- a/upstream_patches/0038-FIPS-TDES-decrypt-disallow.patch
+++ b/upstream_patches/0038-FIPS-TDES-decrypt-disallow.patch
@@ -1,0 +1,73 @@
+From 90e11fd22efd1874941b62bade6ba23994515a92 Mon Sep 17 00:00:00 2001
+From: nkraetzschmar <9020053+nkraetzschmar@users.noreply.github.com>
+Date: Fri, 12 Jun 2026 12:53:32 +0000
+Subject: [PATCH] providers: flag Triple-DES decryption as legacy-use only
+
+FIPS 140-3 marks Triple-DES decryption (in ECB and CBC modes) as
+legacy-use only. Mirror the existing tdes_encrypt_disallowed indicator
+on the decrypt path: tdes_encrypt_check_approved() now also fires
+OSSL_FIPS_IND_ON_UNAPPROVED with a new tdes_decrypt_disallowed config
+flag when called with enc=0, so the operation reports unapproved in
+FIPS mode unless the caller opts in via the indicator.
+---
+ providers/fips/include/fips_indicator_params.inc      |  1 +
+ .../implementations/ciphers/cipher_tdes_common.c      | 11 +++++++++++
+ util/perl/OpenSSL/paramnames.pm                       |  1 +
+ 3 files changed, 13 insertions(+)
+
+diff --git a/providers/fips/include/fips_indicator_params.inc b/providers/fips/include/fips_indicator_params.inc
+index de0e372548..96d55ea194 100644
+--- a/providers/fips/include/fips_indicator_params.inc
++++ b/providers/fips/include/fips_indicator_params.inc
+@@ -16,6 +16,7 @@ OSSL_FIPS_PARAM(dsa_sign_disallowed, DSA_SIGN_DISABLED, 1)
+ OSSL_FIPS_PARAM(dsa_verify_disallowed, DSA_VERIFY_DISABLED, 1)
+ OSSL_FIPS_PARAM(ecdsa_verify_disallowed, ECDSA_VERIFY_DISABLED, 1)
+ OSSL_FIPS_PARAM(tdes_encrypt_disallowed, TDES_ENCRYPT_DISABLED, 1)
++OSSL_FIPS_PARAM(tdes_decrypt_disallowed, TDES_DECRYPT_DISABLED, 1)
+ OSSL_FIPS_PARAM(rsa_pkcs15_padding_disabled, RSA_PKCS15_PAD_DISABLED, 1)
+ OSSL_FIPS_PARAM(rsa_no_padding_disabled, RSA_NO_PAD_DISABLED, 1)
+ OSSL_FIPS_PARAM(rsa_pss_saltlen_check, RSA_PSS_SALTLEN_CHECK, 1)
+diff --git a/providers/implementations/ciphers/cipher_tdes_common.c b/providers/implementations/ciphers/cipher_tdes_common.c
+index 80c38d9d32..3c46ba48f8 100644
+--- a/providers/implementations/ciphers/cipher_tdes_common.c
++++ b/providers/implementations/ciphers/cipher_tdes_common.c
+@@ -19,6 +19,9 @@
+ #include "cipher_tdes.h"
+ #include "prov/implementations.h"
+ #include "prov/providercommon.h"
++#ifdef FIPS_MODULE
++# include "internal/fips.h"
++#endif
+ 
+ void *ossl_tdes_newctx(void *provctx, int mode, size_t kbits, size_t blkbits,
+     size_t ivbits, uint64_t flags, const PROV_CIPHER_HW *hw)
+@@ -68,6 +71,14 @@ static int tdes_encrypt_check_approved(PROV_TDES_CTX *ctx, int enc)
+     /* Triple-DES encryption is not approved in FIPS 140-3 */
+     if (enc && !OSSL_FIPS_IND_ON_UNAPPROVED(ctx, OSSL_FIPS_IND_SETTABLE0, ctx->base.libctx, "Triple-DES", "Encryption", ossl_fips_config_tdes_encrypt_disallowed))
+         return 0;
++    /*
++     * Triple-DES decryption is only allowed for legacy use. Skip the check
++     * during the FIPS provider self-test, where the cipher KAT exercises the
++     * decrypt path before any caller has a chance to install the indicator.
++     */
++    if (!enc && !ossl_fips_self_testing()
++            && !OSSL_FIPS_IND_ON_UNAPPROVED(ctx, OSSL_FIPS_IND_SETTABLE1, ctx->base.libctx, "Triple-DES", "Decryption", ossl_fips_config_tdes_decrypt_disallowed))
++        return 0;
+     return 1;
+ }
+ #endif
+diff --git a/util/perl/OpenSSL/paramnames.pm b/util/perl/OpenSSL/paramnames.pm
+index 240b29cba3..ff7c723714 100644
+--- a/util/perl/OpenSSL/paramnames.pm
++++ b/util/perl/OpenSSL/paramnames.pm
+@@ -47,6 +47,7 @@ my %params = (
+     'PROV_PARAM_DSA_VERIFY_DISABLED' =>    "dsa-verify-disabled",    # uint
+     'PROV_PARAM_ECDSA_VERIFY_DISABLED' =>  "ecdsa-verify-disabled",  # uint
+     'PROV_PARAM_TDES_ENCRYPT_DISABLED' =>  "tdes-encrypt-disabled",  # uint
++    'PROV_PARAM_TDES_DECRYPT_DISABLED' =>  "tdes-decrypt-disabled",  # uint
+     'PROV_PARAM_RSA_PSS_SALTLEN_CHECK' =>  "rsa-pss-saltlen-check",  # uint
+     'PROV_PARAM_RSA_SIGN_X931_PAD_DISABLED' =>  "rsa-sign-x931-pad-disabled",   # uint
+     'PROV_PARAM_RSA_PKCS15_PAD_DISABLED' => "rsa-pkcs15-pad-disabled", # uint
+-- 
+2.47.3
+

--- a/upstream_patches/0039-FIPS-RSA-no-padding-sign-indicator.patch
+++ b/upstream_patches/0039-FIPS-RSA-no-padding-sign-indicator.patch
@@ -1,0 +1,36 @@
+From 4ea90b2abd845715f7e9a7481466d15bda48cb35 Mon Sep 17 00:00:00 2001
+From: nkraetzschmar <9020053+nkraetzschmar@users.noreply.github.com>
+Date: Fri, 12 Jun 2026 13:30:37 +0000
+Subject: [PATCH] providers: flag RSA signing with no padding as unapproved
+
+FIPS 140-3 IG 2.4.B treats raw RSA signature primitives as component
+algorithms that must not be used standalone. Patch 0032 already gates
+the encrypt path against pad_mode == RSA_NO_PADDING; mirror that
+behaviour in rsa_sign_directly() so a sign call with no padding goes
+through OSSL_FIPS_IND_ON_UNAPPROVED and reuses the existing
+rsa_no_padding_disabled config flag.
+---
+ providers/implementations/signature/rsa_sig.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/providers/implementations/signature/rsa_sig.c b/providers/implementations/signature/rsa_sig.c
+index 54d9e9abb8..e38f14224b 100644
+--- a/providers/implementations/signature/rsa_sig.c
++++ b/providers/implementations/signature/rsa_sig.c
+@@ -704,6 +704,13 @@ static int rsa_sign_directly(PROV_RSA_CTX *prsactx,
+ #ifdef FIPS_MODULE
+     if (!rsa_pkcs15_primitive_padding_allowed(prsactx, "RSA Sign"))
+         return 0;
++    if (prsactx->pad_mode == RSA_NO_PADDING
++        && !OSSL_FIPS_IND_ON_UNAPPROVED(prsactx, OSSL_FIPS_IND_SETTABLE5,
++            prsactx->libctx, "RSA Sign", "No padding",
++            ossl_fips_config_rsa_no_padding_disabled)) {
++        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_PADDING_MODE);
++        return 0;
++    }
+ #endif
+ 
+     if (sig == NULL) {
+-- 
+2.47.3
+

--- a/upstream_patches/0040-FIPS-ML-KEM-zeroize-intermediate-buffers.patch
+++ b/upstream_patches/0040-FIPS-ML-KEM-zeroize-intermediate-buffers.patch
@@ -1,0 +1,147 @@
+From f87dc452585963b00e5c3cfffefe39e094a9c5f2 Mon Sep 17 00:00:00 2001
+From: nkraetzschmar <9020053+nkraetzschmar@users.noreply.github.com>
+Date: Fri, 12 Jun 2026 13:54:45 +0000
+Subject: [PATCH] providers: zeroize ML-KEM intermediate values
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+FIPS 203 §3.3 requires implementations to zeroize any intermediate
+parameter generated during ML-KEM internal calculations. Patch 0017
+already covered |mask| and |failure_key| in decap()'s success path;
+extend the coverage:
+
+  * encap() now cleanses |Kr| (shared secret K and FO randomness r)
+    before returning.
+  * encrypt_cpa() now cleanses the secret polynomial |v| and |input|
+    (counter+r seed) on every exit path via a goto-err pattern.
+  * cbd_2() and cbd_3() cleanse |randbuf| (PRF output for secret
+    sampling) before returning.
+  * gencbd_vector() and gencbd_vector_ntt() cleanse |input|
+    (counter+seed) before returning, including the early-error path.
+  * The case_decap() macro now cleanses |cbuf| (the re-encrypted
+    ciphertext used for FO comparison) alongside the existing |tmp|
+    cleanse.
+  * decap()'s catastrophic-error early return now also cleanses |Kr|
+    and |failure_key|, matching the regular return path.
+---
+ crypto/ml_kem/ml_kem.c | 28 +++++++++++++++++++++++-----
+ 1 file changed, 23 insertions(+), 5 deletions(-)
+
+diff --git a/crypto/ml_kem/ml_kem.c b/crypto/ml_kem/ml_kem.c
+index 23dfa02523..44532f0d92 100644
+--- a/crypto/ml_kem/ml_kem.c
++++ b/crypto/ml_kem/ml_kem.c
+@@ -1363,6 +1363,7 @@ static __owur int cbd_2(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
+         mask = constish_time_non_zero(value >> 15);
+         *curr++ = value + (kPrime & mask);
+     } while (curr < end);
++    OPENSSL_cleanse(randbuf, sizeof(randbuf));
+     return 1;
+ }
+ 
+@@ -1415,6 +1416,7 @@ static __owur int cbd_3(scalar *out, uint8_t in[ML_KEM_RANDOM_BYTES + 1],
+         mask = constish_time_non_zero(value >> 15);
+         *curr++ = value + (kPrime & mask);
+     } while (curr < end);
++    OPENSSL_cleanse(randbuf, sizeof(randbuf));
+     return 1;
+ }
+ 
+@@ -1431,9 +1433,12 @@ static __owur int gencbd_vector(scalar *out, CBD_FUNC cbd, uint8_t *counter,
+     memcpy(input, seed, ML_KEM_RANDOM_BYTES);
+     do {
+         input[ML_KEM_RANDOM_BYTES] = (*counter)++;
+-        if (!cbd(out++, input, mdctx, key))
++        if (!cbd(out++, input, mdctx, key)) {
++            OPENSSL_cleanse(input, sizeof(input));
+             return 0;
++        }
+     } while (--rank > 0);
++    OPENSSL_cleanse(input, sizeof(input));
+     return 1;
+ }
+ 
+@@ -1449,10 +1454,13 @@ static __owur int gencbd_vector_ntt(scalar *out, CBD_FUNC cbd, uint8_t *counter,
+     memcpy(input, seed, ML_KEM_RANDOM_BYTES);
+     do {
+         input[ML_KEM_RANDOM_BYTES] = (*counter)++;
+-        if (!cbd(out, input, mdctx, key))
++        if (!cbd(out, input, mdctx, key)) {
++            OPENSSL_cleanse(input, sizeof(input));
+             return 0;
++        }
+         scalar_ntt(out++);
+     } while (--rank > 0);
++    OPENSSL_cleanse(input, sizeof(input));
+     return 1;
+ }
+ 
+@@ -1495,7 +1503,7 @@ static __owur int encrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
+ 
+     /* FIPS 203 "y" vector */
+     if (!gencbd_vector_ntt(y, cbd_1, &counter, r, rank, mdctx, key))
+-        return 0;
++        goto err;
+     /* FIPS 203 "v" scalar */
+     inner_product(&v, key->t, y, rank);
+     scalar_inverse_ntt(&v);
+@@ -1504,7 +1512,7 @@ static __owur int encrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
+ 
+     /* All done with |y|, now free to reuse tmp[0] for FIPS 203 |e1| */
+     if (!gencbd_vector(e1, cbd_2, &counter, r, rank, mdctx, key))
+-        return 0;
++        goto err;
+     vector_add(u, e1, rank);
+     vector_compress(u, du, rank);
+     vector_encode(out, u, du, rank);
+@@ -1513,14 +1521,20 @@ static __owur int encrypt_cpa(uint8_t out[ML_KEM_SHARED_SECRET_BYTES],
+     memcpy(input, r, ML_KEM_RANDOM_BYTES);
+     input[ML_KEM_RANDOM_BYTES] = counter;
+     if (!cbd_2(e2, input, mdctx, key))
+-        return 0;
++        goto err;
+     scalar_add(&v, e2);
+ 
+     /* Combine message with |v| */
+     scalar_decode_decompress_add(&v, message);
+     scalar_compress(&v, dv);
+     scalar_encode(out + vinfo->u_vector_bytes, &v, dv);
++    OPENSSL_cleanse((void *)&v, sizeof(v));
++    OPENSSL_cleanse((void *)input, sizeof(input));
+     return 1;
++err:
++    OPENSSL_cleanse((void *)&v, sizeof(v));
++    OPENSSL_cleanse((void *)input, sizeof(input));
++    return 0;
+ }
+ 
+ /*
+@@ -1776,6 +1790,7 @@ static int encap(uint8_t *ctext, uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
+         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR,
+             "internal error while performing %s encapsulation",
+             key->vinfo->algorithm_name);
++    OPENSSL_cleanse((void *)Kr, sizeof(Kr));
+     return ret;
+ }
+ 
+@@ -1830,6 +1845,8 @@ static int decap(uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
+         || !encrypt_cpa(tmp_ctext, decrypted, r, tmp, mdctx, key)) {
+         memcpy(secret, failure_key, ML_KEM_SHARED_SECRET_BYTES);
+         OPENSSL_cleanse(decrypted, ML_KEM_SHARED_SECRET_BYTES);
++        OPENSSL_cleanse(Kr, sizeof(Kr));
++        OPENSSL_cleanse(failure_key, ML_KEM_RANDOM_BYTES);
+         return 1;
+     }
+     mask = constant_time_eq_int_8(0,
+@@ -2328,6 +2345,7 @@ int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
+                                                                   \
+         ret = decap(shared_secret, ctext, cbuf, tmp, mdctx, key); \
+         OPENSSL_cleanse((void *)tmp, sizeof(tmp));                \
++        OPENSSL_cleanse((void *)cbuf, sizeof(cbuf));              \
+         break;                                                    \
+     }
+     switch (vinfo->evp_type) {
+-- 
+2.47.3
+

--- a/upstream_patches/0041-FIPS-RSA-X931-verify-disallow.patch
+++ b/upstream_patches/0041-FIPS-RSA-X931-verify-disallow.patch
@@ -1,0 +1,53 @@
+From dcef8612e3ef5b997ed2e0e7081ec9e2511f707f Mon Sep 17 00:00:00 2001
+From: nkraetzschmar <9020053+nkraetzschmar@users.noreply.github.com>
+Date: Fri, 12 Jun 2026 14:27:45 +0000
+Subject: [PATCH] providers: flag RSA verify with X9.31 padding as unapproved
+
+FIPS 186-5 (and the corresponding FIPS 140-3 IG D.K guidance) does not
+list X9.31 as an approved padding scheme for new RSA signature use; the
+verify side is at most legacy-use. The existing rsa_x931_padding_allowed()
+check only covered the sign operations; extend the operation mask to
+cover EVP_PKEY_OP_VERIFYMSG / EVP_PKEY_OP_VERIFY too, and add a matching
+OSSL_FIPS_IND_ON_UNAPPROVED hook in rsa_verify_directly() so the
+indicator also fires when the X9.31 padding is inherited from a context
+where the padding was already set.
+---
+ providers/implementations/signature/rsa_sig.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/providers/implementations/signature/rsa_sig.c b/providers/implementations/signature/rsa_sig.c
+index e38f14224b..08469803ae 100644
+--- a/providers/implementations/signature/rsa_sig.c
++++ b/providers/implementations/signature/rsa_sig.c
+@@ -1060,6 +1060,13 @@ static int rsa_verify_directly(PROV_RSA_CTX *prsactx,
+ #ifdef FIPS_MODULE
+     if (!rsa_pkcs15_primitive_padding_allowed(prsactx, "RSA Verify"))
+         return 0;
++    if (prsactx->pad_mode == RSA_X931_PADDING
++        && !OSSL_FIPS_IND_ON_UNAPPROVED(prsactx, OSSL_FIPS_IND_SETTABLE2,
++            prsactx->libctx, "RSA Verify", "X931 Padding",
++            ossl_fips_config_rsa_sign_x931_disallowed)) {
++        ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
++        return 0;
++    }
+ #endif
+ 
+     if (prsactx->md != NULL) {
+@@ -1546,11 +1553,12 @@ static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *vprsactx,
+ static int rsa_x931_padding_allowed(PROV_RSA_CTX *ctx)
+ {
+     if ((ctx->operation
+-            & (EVP_PKEY_OP_SIGNMSG | EVP_PKEY_OP_SIGN))
++            & (EVP_PKEY_OP_SIGNMSG | EVP_PKEY_OP_SIGN
++                | EVP_PKEY_OP_VERIFYMSG | EVP_PKEY_OP_VERIFY))
+         != 0) {
+         if (!OSSL_FIPS_IND_ON_UNAPPROVED(ctx, OSSL_FIPS_IND_SETTABLE2,
+                 ctx->libctx,
+-                "RSA Sign set ctx", "X931 Padding",
++                "RSA", "X931 Padding",
+                 ossl_fips_config_rsa_sign_x931_disallowed)) {
+             ERR_raise(ERR_LIB_PROV,
+                 PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
+-- 
+2.47.3
+

--- a/upstream_patches/0042-FIPS-RSA-verify-min-modulus-indicator.patch
+++ b/upstream_patches/0042-FIPS-RSA-verify-min-modulus-indicator.patch
@@ -1,0 +1,62 @@
+From 386b9cb5c985f34c0874917f149c2211b0446c5f Mon Sep 17 00:00:00 2001
+From: nkraetzschmar <9020053+nkraetzschmar@users.noreply.github.com>
+Date: Fri, 12 Jun 2026 15:15:55 +0000
+Subject: [PATCH] providers: flag RSA verify with <2048-bit modulus as
+ unapproved
+
+FIPS 186-5 / SP 800-131A treat RSA signature verification with moduli
+shorter than 2048 bits as legacy-use only: such moduli give less than
+112 bits of security strength and are not approved for new signature
+verification work. ossl_rsa_check_key_size() still allows 1024-bit
+moduli on the verify side (protect=0) for backward compatibility, so
+add an indicator gate at the top of rsa_verify_directly(): when the
+modulus is shorter than 2048 bits, run OSSL_FIPS_IND_ON_UNAPPROVED
+through a new rsa_verify_min_modulus_disallowed config flag.
+---
+ providers/fips/include/fips_indicator_params.inc | 1 +
+ providers/implementations/signature/rsa_sig.c    | 7 +++++++
+ util/perl/OpenSSL/paramnames.pm                  | 1 +
+ 3 files changed, 9 insertions(+)
+
+diff --git a/providers/fips/include/fips_indicator_params.inc b/providers/fips/include/fips_indicator_params.inc
+index 96d55ea194..19a2e5fc64 100644
+--- a/providers/fips/include/fips_indicator_params.inc
++++ b/providers/fips/include/fips_indicator_params.inc
+@@ -36,3 +36,4 @@ OSSL_FIPS_PARAM(ml_kem_seed_check, ML_KEM_SEED_CHECK, 1)
+ OSSL_FIPS_PARAM(ml_dsa_seed_check, ML_DSA_SEED_CHECK, 1)
+ OSSL_FIPS_PARAM(slh_dsa_sign_entropy_check, SLH_DSA_SIGN_ENTROPY_CHECK, 1)
+ OSSL_FIPS_PARAM(slh_dsa_seed_check, SLH_DSA_SEED_CHECK, 1)
++OSSL_FIPS_PARAM(rsa_verify_min_modulus_disallowed, RSA_VERIFY_MIN_MODULUS_DISABLED, 1)
+diff --git a/providers/implementations/signature/rsa_sig.c b/providers/implementations/signature/rsa_sig.c
+index 08469803ae..a6b7123709 100644
+--- a/providers/implementations/signature/rsa_sig.c
++++ b/providers/implementations/signature/rsa_sig.c
+@@ -1067,6 +1067,13 @@ static int rsa_verify_directly(PROV_RSA_CTX *prsactx,
+         ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
+         return 0;
+     }
++    if (RSA_bits(prsactx->rsa) < 2048
++        && !OSSL_FIPS_IND_ON_UNAPPROVED(prsactx, OSSL_FIPS_IND_SETTABLE6,
++            prsactx->libctx, "RSA Verify", "Modulus less than 2048 bits",
++            ossl_fips_config_rsa_verify_min_modulus_disallowed)) {
++        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
++        return 0;
++    }
+ #endif
+ 
+     if (prsactx->md != NULL) {
+diff --git a/util/perl/OpenSSL/paramnames.pm b/util/perl/OpenSSL/paramnames.pm
+index ff7c723714..663c86b717 100644
+--- a/util/perl/OpenSSL/paramnames.pm
++++ b/util/perl/OpenSSL/paramnames.pm
+@@ -52,6 +52,7 @@ my %params = (
+     'PROV_PARAM_RSA_SIGN_X931_PAD_DISABLED' =>  "rsa-sign-x931-pad-disabled",   # uint
+     'PROV_PARAM_RSA_PKCS15_PAD_DISABLED' => "rsa-pkcs15-pad-disabled", # uint
+     'PROV_PARAM_RSA_NO_PAD_DISABLED' => "rsa-no-pad-disabled", # uint
++    'PROV_PARAM_RSA_VERIFY_MIN_MODULUS_DISABLED' => "rsa-verify-min-modulus-disabled", # uint
+     'PROV_PARAM_HKDF_KEY_CHECK' =>         "hkdf-key-check",         # uint
+     'PROV_PARAM_KBKDF_KEY_CHECK' =>        "kbkdf-key-check",        # uint
+     'PROV_PARAM_TLS13_KDF_KEY_CHECK' =>    "tls13-kdf-key-check",    # uint
+-- 
+2.47.3
+

--- a/upstream_patches/0043-FIPS-ECDSA-P192-verify-disallow.patch
+++ b/upstream_patches/0043-FIPS-ECDSA-P192-verify-disallow.patch
@@ -1,0 +1,60 @@
+From 45bf81d75e8c8dd28fec8c762ee034070536adf7 Mon Sep 17 00:00:00 2001
+From: nkraetzschmar <9020053+nkraetzschmar@users.noreply.github.com>
+Date: Fri, 12 Jun 2026 15:33:59 +0000
+Subject: [PATCH] providers: flag ECDSA verify with P-192 curve as unapproved
+
+FIPS 186-5 / SP 800-131A treat ECDSA signature verification using the
+P-192 curve (NID_X9_62_prime192v1) as legacy-use only: the curve gives
+only 96 bits of security strength, below the FIPS 112-bit minimum for
+new use but still permitted via ossl_ec_check_security_strength()'s
+legacy 80-bit threshold for the verify direction. Add an indicator
+gate at the top of ecdsa_verify_directly(): when the key's curve is
+prime192v1, run OSSL_FIPS_IND_ON_UNAPPROVED through a new
+ecdsa_p192_verify_disallowed config flag.
+---
+ providers/fips/include/fips_indicator_params.inc | 1 +
+ providers/implementations/signature/ecdsa_sig.c  | 6 ++++++
+ util/perl/OpenSSL/paramnames.pm                  | 1 +
+ 3 files changed, 8 insertions(+)
+
+diff --git a/providers/fips/include/fips_indicator_params.inc b/providers/fips/include/fips_indicator_params.inc
+index 19a2e5fc64..6e2a2dc845 100644
+--- a/providers/fips/include/fips_indicator_params.inc
++++ b/providers/fips/include/fips_indicator_params.inc
+@@ -37,3 +37,4 @@ OSSL_FIPS_PARAM(ml_dsa_seed_check, ML_DSA_SEED_CHECK, 1)
+ OSSL_FIPS_PARAM(slh_dsa_sign_entropy_check, SLH_DSA_SIGN_ENTROPY_CHECK, 1)
+ OSSL_FIPS_PARAM(slh_dsa_seed_check, SLH_DSA_SEED_CHECK, 1)
+ OSSL_FIPS_PARAM(rsa_verify_min_modulus_disallowed, RSA_VERIFY_MIN_MODULUS_DISABLED, 1)
++OSSL_FIPS_PARAM(ecdsa_p192_verify_disallowed, ECDSA_P192_VERIFY_DISABLED, 1)
+diff --git a/providers/implementations/signature/ecdsa_sig.c b/providers/implementations/signature/ecdsa_sig.c
+index 253c711ce5..08f8ee828e 100644
+--- a/providers/implementations/signature/ecdsa_sig.c
++++ b/providers/implementations/signature/ecdsa_sig.c
+@@ -450,6 +450,12 @@ static int ecdsa_verify_directly(void *vctx,
+             ctx->libctx, "ECDSA Verify", "Component verification",
+             ossl_fips_config_ecdsa_verify_disallowed))
+         return 0;
++    if (EC_GROUP_get_curve_name(EC_KEY_get0_group(ctx->ec))
++            == NID_X9_62_prime192v1
++        && !OSSL_FIPS_IND_ON_UNAPPROVED(ctx, OSSL_FIPS_IND_SETTABLE3,
++            ctx->libctx, "ECDSA Verify", "P-192 curve",
++            ossl_fips_config_ecdsa_p192_verify_disallowed))
++        return 0;
+ #endif
+ 
+     return ECDSA_verify(0, tbs, tbslen, sig, siglen, ctx->ec);
+diff --git a/util/perl/OpenSSL/paramnames.pm b/util/perl/OpenSSL/paramnames.pm
+index 663c86b717..7f3859aa90 100644
+--- a/util/perl/OpenSSL/paramnames.pm
++++ b/util/perl/OpenSSL/paramnames.pm
+@@ -53,6 +53,7 @@ my %params = (
+     'PROV_PARAM_RSA_PKCS15_PAD_DISABLED' => "rsa-pkcs15-pad-disabled", # uint
+     'PROV_PARAM_RSA_NO_PAD_DISABLED' => "rsa-no-pad-disabled", # uint
+     'PROV_PARAM_RSA_VERIFY_MIN_MODULUS_DISABLED' => "rsa-verify-min-modulus-disabled", # uint
++    'PROV_PARAM_ECDSA_P192_VERIFY_DISABLED' => "ecdsa-p192-verify-disabled", # uint
+     'PROV_PARAM_HKDF_KEY_CHECK' =>         "hkdf-key-check",         # uint
+     'PROV_PARAM_KBKDF_KEY_CHECK' =>        "kbkdf-key-check",        # uint
+     'PROV_PARAM_TLS13_KDF_KEY_CHECK' =>    "tls13-kdf-key-check",    # uint
+-- 
+2.47.3
+

--- a/upstream_patches/0044-FIPS-ML-KEM-encap-key-check.patch
+++ b/upstream_patches/0044-FIPS-ML-KEM-encap-key-check.patch
@@ -1,0 +1,60 @@
+From 26d0c16071bf7321c21b72b514ad352bc63f766d Mon Sep 17 00:00:00 2001
+From: nkraetzschmar <9020053+nkraetzschmar@users.noreply.github.com>
+Date: Fri, 12 Jun 2026 15:57:14 +0000
+Subject: [PATCH] providers: range-check ML-KEM encapsulation key at encap
+ entry
+
+FIPS 203 Section 7.2 requires the module to validate the candidate
+encapsulation key before performing the encapsulation. The decoder
+already enforces 'each coefficient < q = ML_KEM_PRIME' on import via
+scalar_decode_12(), but the check is not re-asserted at operation
+time. Add a defense-in-depth pass at the top of
+ossl_ml_kem_encap_seed() (which also covers ossl_ml_kem_encap_rand()
+since the latter delegates to it) that walks key->t and rejects any
+coefficient outside [0, ML_KEM_PRIME).
+---
+ crypto/ml_kem/ml_kem.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/crypto/ml_kem/ml_kem.c b/crypto/ml_kem/ml_kem.c
+index 44532f0d92..358f388778 100644
+--- a/crypto/ml_kem/ml_kem.c
++++ b/crypto/ml_kem/ml_kem.c
+@@ -2236,6 +2236,8 @@ int ossl_ml_kem_encap_seed(uint8_t *ctext, size_t clen,
+ {
+     const ML_KEM_VINFO *vinfo;
+     EVP_MD_CTX *mdctx;
++    const scalar *t, *end;
++    int i;
+     int ret = 0;
+ 
+     if (key == NULL || !ossl_ml_kem_have_pubkey(key))
+@@ -2247,6 +2249,25 @@ int ossl_ml_kem_encap_seed(uint8_t *ctext, size_t clen,
+         || entropy == NULL || elen != ML_KEM_RANDOM_BYTES
+         || (mdctx = EVP_MD_CTX_new()) == NULL)
+         return 0;
++
++    /*
++     * FIPS 203 Section 7.2 requires the encapsulation key to be range-checked
++     * before use: each public-key vector coefficient must be a valid element
++     * of the field Z_q.  ossl_ml_kem_parse_public_key() already enforces this
++     * on import via scalar_decode_12(), but re-assert it here so that the
++     * check is also performed at the encapsulation entry point.
++     */
++    for (t = key->t, end = t + vinfo->rank; t < end; ++t) {
++        for (i = 0; i < ML_KEM_DEGREE; ++i) {
++            if (t->c[i] >= ML_KEM_PRIME) {
++                EVP_MD_CTX_free(mdctx);
++                ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
++                    "%s encapsulation key has out-of-range coefficient",
++                    vinfo->algorithm_name);
++                return 0;
++            }
++        }
++    }
+     /*
+      * Data derived from the encap entropy defaults secret, and to avoid
+      * side-channel leaks should not influence control flow.
+-- 
+2.47.3
+

--- a/upstream_patches/0045-FIPS-ML-KEM-decap-key-check.patch
+++ b/upstream_patches/0045-FIPS-ML-KEM-decap-key-check.patch
@@ -1,0 +1,72 @@
+From d5a53156e9da26dceb722a310382e1389b83840d Mon Sep 17 00:00:00 2001
+From: nkraetzschmar <9020053+nkraetzschmar@users.noreply.github.com>
+Date: Fri, 12 Jun 2026 16:17:15 +0000
+Subject: [PATCH] providers: validate ML-KEM decapsulation key at decap entry
+
+FIPS 203 Section 7.3 requires the module to validate the candidate
+decapsulation key (and check the received ciphertext) before
+performing decapsulation. ossl_ml_kem_parse_private_key() already
+verifies the embedded H(ek) == key->pkhash relationship at import
+time, but the check is not re-asserted at operation time; do that at
+the top of ossl_ml_kem_decap() by recomputing H(ek) via the existing
+hash_h_pubkey() helper and comparing against key->pkhash.
+
+The spec also calls for a coefficient-range check on the received
+ciphertext.  ML-KEM ciphertexts are encoded at du and dv bits per
+coefficient; scalar_decode() masks the extracted bits to exactly that
+width, so all decoded coefficients are structurally in [0, 2^du) and
+[0, 2^dv).  Document this in the new comment block and skip the
+explicit range gate.
+---
+ crypto/ml_kem/ml_kem.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/crypto/ml_kem/ml_kem.c b/crypto/ml_kem/ml_kem.c
+index 358f388778..63be5ee936 100644
+--- a/crypto/ml_kem/ml_kem.c
++++ b/crypto/ml_kem/ml_kem.c
+@@ -2327,6 +2327,7 @@ int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
+ {
+     const ML_KEM_VINFO *vinfo;
+     EVP_MD_CTX *mdctx;
++    uint8_t expected_pkhash[ML_KEM_PKHASH_BYTES];
+     int ret = 0;
+ #if defined(OPENSSL_CONSTANT_TIME_VALIDATION)
+     int classify_bytes;
+@@ -2344,6 +2345,33 @@ int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
+             ML_KEM_SHARED_SECRET_BYTES, vinfo->secbits);
+         return 0;
+     }
++
++    /*
++     * FIPS 203 Section 7.3 requires the module to validate the candidate
++     * decapsulation key before decapsulation: in particular the embedded
++     * H(ek) must match the encapsulation-key components stored alongside it.
++     * ossl_ml_kem_parse_private_key() already enforces this at import time
++     * (see the memcmp(key->pkhash, ...) guard there); re-assert it here so
++     * the check also runs at the decapsulation entry point.
++     *
++     * Note: the spec also calls for a coefficient-range check on the
++     * received ciphertext.  ML-KEM's ciphertext is encoded with du and dv
++     * bits per coefficient, and scalar_decode() masks each extracted value
++     * to exactly that bit width, so all decoded coefficients are
++     * structurally in [0, 2^du) and [0, 2^dv); no explicit range gate is
++     * required.
++     */
++    if (!hash_h_pubkey(expected_pkhash, mdctx, (ML_KEM_KEY *)key)) {
++        EVP_MD_CTX_free(mdctx);
++        return 0;
++    }
++    if (memcmp(expected_pkhash, key->pkhash, ML_KEM_PKHASH_BYTES) != 0) {
++        EVP_MD_CTX_free(mdctx);
++        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
++            "%s decapsulation key hash mismatch",
++            vinfo->algorithm_name);
++        return 0;
++    }
+ #if defined(OPENSSL_CONSTANT_TIME_VALIDATION)
+     /*
+      * Data derived from |s| and |z| defaults secret, and to avoid side-channel
+-- 
+2.47.3
+

--- a/upstream_patches/series
+++ b/upstream_patches/series
@@ -37,3 +37,12 @@ rsa_kem-test-RSA_public_encrypt-result-in-RSASVE.patch
 0034-FIPS-ECDSA-verify-indicator.patch
 0035-FIPS-SLH-DSA-sign-entropy-indicator.patch
 0036-FIPS-SLH-DSA-keygen-seed-indicator.patch
+0037-FIPS-ECDSA-allow-truncated-SHA512.patch
+0038-FIPS-TDES-decrypt-disallow.patch
+0039-FIPS-RSA-no-padding-sign-indicator.patch
+0040-FIPS-ML-KEM-zeroize-intermediate-buffers.patch
+0041-FIPS-RSA-X931-verify-disallow.patch
+0042-FIPS-RSA-verify-min-modulus-indicator.patch
+0043-FIPS-ECDSA-P192-verify-disallow.patch
+0044-FIPS-ML-KEM-encap-key-check.patch
+0045-FIPS-ML-KEM-decap-key-check.patch


### PR DESCRIPTION
Various FIPS-related patches:

- `0037-FIPS-ECDSA-allow-truncated-SHA512.patch`: Stop reporting SHA2-512/224 and SHA2-512/256 as unapproved for ECDSA, they are FIPS 186-5 approved.
- `0038-FIPS-TDES-decrypt-disallow.patch`: Flag Triple-DES decryption as legacy-use only; new `tdes-decrypt-disabled` config flag, KAT-safe.
- `0039-FIPS-RSA-no-padding-sign-indicator.patch`: Gate RSA signing with `RSA_NO_PADDING` through the existing `rsa_no_padding_disabled` indicator.
- `0040-FIPS-ML-KEM-zeroize-intermediate-buffers.patch`: Cleanse intermediate buffers in `encap()`, `encrypt_cpa()`, `cbd_2/3()`, `gencbd_vector{,_ntt}()`, `case_decap`, and the decap catastrophic-error path.
- `0041-FIPS-RSA-X931-verify-disallow.patch`: Extend the X9.31 padding indicator to RSA verify operations.
- `0042-FIPS-RSA-verify-min-modulus-indicator.patch`: Flag RSA verify with moduli below 2048 bits via a new `rsa-verify-min-modulus-disabled` indicator.
- `0043-FIPS-ECDSA-P192-verify-disallow.patch`: Flag ECDSA verify on P-192 via a new `ecdsa-p192-verify-disabled` indicator.
- `0044-FIPS-ML-KEM-encap-key-check.patch`: Re-assert public-key coefficient range at `ossl_ml_kem_encap_seed()` entry per FIPS 203 §7.2.
- `0045-FIPS-ML-KEM-decap-key-check.patch`: Recompute and verify `H(ek) == key->pkhash` at `ossl_ml_kem_decap()` entry per FIPS 203 §7.3.

## Findings addressed

| Finding | Patches |
| --- | --- |
| 14 — ML-KEM encapsulation key check | `0044` |
| 15 — ML-KEM decapsulation key/ciphertext check | `0045` |
| 16 — ML-KEM intermediate-value zeroizations | `0040` |
| 29 — Legacy-use indicators (TDES decrypt, RSA <2048 verify, RSA X9.31 verify, ECDSA P-192 verify) | `0038`, `0041`, `0042`, `0043` (DSA-sigVer sub-item already covered by `0028`) |
| 30 — IG 2.4.B CVL primitives | `0039` (RSA-decrypt no-padding and ECDSA-sigGen-component sub-items already covered by `0032` and `0034`) |
| 31 — ECDSA truncated SHA-512 wrongly non-approved | `0037` |